### PR TITLE
shsingh/modify k6 and newman tests

### DIFF
--- a/argocd/manifests/hapi/hapi-waf-policy.yaml
+++ b/argocd/manifests/hapi/hapi-waf-policy.yaml
@@ -195,4 +195,4 @@ spec:
           - name: suspicious-browser
             action: block
           - name: unknown
-            action: block
+            action: ignore


### PR DESCRIPTION
- debug dos and rename protected-resource manifest
- disable debug on dos
- modify dogLogDest to dosAccessLogDest in manifests
- add both dosLogDest and dosAccessLogDest
- fix typo for dosAccessLogDest location
- ignore blocking unknown bot for hapi
