### PR TITLE
shsingh/modify k6 and newman tests

### DIFF
--- a/argocd/manifests/hapi/hapi-waf-policy.yaml
+++ b/argocd/manifests/hapi/hapi-waf-policy.yaml
@@ -156,7 +156,7 @@ spec:
           block: false
         - name: VIOL_THREAT_CAMPAIGN
           alarm: false
-          block: true
+          block: false
         - name: VIOL_URL
           alarm: false
           block: false
@@ -187,7 +187,7 @@ spec:
           - name: trusted-bot
             action: ignore
           - name: untrusted-bot
-            action: block
+            action: ignore
           - name: malicious-bot
             action: block
           - name: browser


### PR DESCRIPTION
- debug dos and rename protected-resource manifest
- disable debug on dos
- modify dogLogDest to dosAccessLogDest in manifests
- add both dosLogDest and dosAccessLogDest
- fix typo for dosAccessLogDest location
- ignore blocking unknown bot for hapi
- ignore threat-campaigns, untrusted-bots for hapi
