### PR TITLE
shsingh/modify k6 and newman tests

### DIFF
--- a/argocd/manifests/hapi/hapi-waf-policy.yaml
+++ b/argocd/manifests/hapi/hapi-waf-policy.yaml
@@ -181,7 +181,7 @@ spec:
         block: false
     bot-defense:
       settings:
-        isEnabled: true
+        isEnabled: false
       mitigations:
         classes:
           - name: trusted-bot


### PR DESCRIPTION
- debug dos and rename protected-resource manifest
- disable debug on dos
- modify dogLogDest to dosAccessLogDest in manifests
- add both dosLogDest and dosAccessLogDest
- fix typo for dosAccessLogDest location
- ignore blocking unknown bot for hapi
- ignore threat-campaigns, untrusted-bots for hapi
- disable hapi bot policy
