### PR TITLE
shsingh/modify k6 and newman tests

### DIFF
--- a/argocd/manifests/hapi/hapi-waf-policy.yaml
+++ b/argocd/manifests/hapi/hapi-waf-policy.yaml
@@ -176,12 +176,63 @@ spec:
           alarm: false
           block: false
     signature-sets:
-      - name: High Accuracy Signatures
+      - name: "XML External Entities (XXE) Signatures"
+        alarm: false
+        block: false
+      - name: "CVE Signatures"
+        alarm: false
+        block: false
+      - name: "Vulnerability Scan Signatures"
+        alarm: false
+        block: false
+      - name: "Denial of Service Signatures"
+        alarm: false
+        block: false
+      - name: "Buffer Overflow Signatures"
+        alarm: false
+        block: false
+      - name: "Authentication/Authorization Attack Signatures"
+        alarm: false
+        block: false
+      - name: "High Accuracy Signatures"
+        alarm: false
+        block: false
+      - name: "SQL Injection Signatures"
+        alarm: false
+        block: false
+      - name: "Cross Site Scripting Signatures"
+        alarm: false
+        block: false
+      - name: "OS Command Injection Signatures"
+        alarm: false
+        block: false
+      - name: "Path Traversal Signatures"
+        alarm: false
+        block: false
+      - name: "XPath Injection Signatures"
+        alarm: false
+        block: false
+      - name: "Command Execution Signatures"
+        alarm: false
+        block: false
+      - name: "Server Side Code Injection Signatures"
+        alarm: false
+        block: false
+      - name: "Information Leakage Signatures"
+        alarm: false
+        block: false
+      - name: "Directory Indexing Signatures"
+        alarm: false
+        block: false
+      - name: "Remote File Include Signatures"
+        alarm: false
+        block: false
+      - name: "Predictable Resource Location Signatures"
         alarm: false
         block: false
     bot-defense:
       settings:
-        isEnabled: false
+        isEnabled: true
       mitigations:
         classes:
           - name: trusted-bot
@@ -189,10 +240,10 @@ spec:
           - name: untrusted-bot
             action: ignore
           - name: malicious-bot
-            action: block
+            action: ignore
           - name: browser
             action: ignore
           - name: suspicious-browser
-            action: block
+            action: ignore
           - name: unknown
             action: ignore


### PR DESCRIPTION
- debug dos and rename protected-resource manifest
- disable debug on dos
- modify dogLogDest to dosAccessLogDest in manifests
- add both dosLogDest and dosAccessLogDest
- fix typo for dosAccessLogDest location
- ignore blocking unknown bot for hapi
- ignore threat-campaigns, untrusted-bots for hapi
- disable hapi bot policy
- ignore all signature sets for hapi
